### PR TITLE
Add ethfaucet.com faucet

### DIFF
--- a/kite-chain/1-getting-started/network-information.md
+++ b/kite-chain/1-getting-started/network-information.md
@@ -21,6 +21,7 @@ description: Chain IDs, endpoints, and environment details for Kite networks.
 ### Faucet
 
 * Testnet - [https://faucet.gokite.ai](https://faucet.gokite.ai)
+* Testnet - [ethfaucet.com](https://ethfaucet.com?utm_source=kiteai_docs&utm_medium=docs)   
 
 ## Kite network settings (mainnet)
 


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with gas on KiteAI network for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.