### PR TITLE
docs: update Kite Mainnet contracts list

### DIFF
--- a/kite-chain/10-layerzero-kite-integration/README.md
+++ b/kite-chain/10-layerzero-kite-integration/README.md
@@ -72,14 +72,14 @@ The canonical and always up-to-date source for contract addresses is maintained 
 
 ### Contracts
 
-| Contract | Description |
-|----------|-------------|
-| EndpointV2 | Primary entry point into LayerZero v2. Manages message sending, receiving, and configuration for OApps. |
-| SendUln302 | Message library used for sending cross-chain messages securely. |
-| ReceiveUln302 | Message library used for receiving and verifying cross-chain messages. |
-| BlockedMessageLib | Safety library for blocking misconfigured or invalid message paths. |
-| LZ Executor | Executes verified messages on Kite AI with a defined gas limit and msg.value. |
-| LZ Dead DVN | Placeholder DVN used when default configs are inactive and manual configuration is required. |
+| Contract | Address | Description |
+|----------|---------|-------------|
+| EndpointV2 | `0x6F475642a6e85809B1c36Fa62763669b1b48DD5B` | Primary entry point into LayerZero v2. Manages message sending, receiving, and configuration for OApps. |
+| SendUln302 | `0xC39161c743D0307EB9BCc9FEF03eeb9Dc4802de7` | Message library used for sending cross-chain messages securely. |
+| ReceiveUln302 | `0xe1844c5D63a9543023008D332Bd3d2e6f1FE1043` | Message library used for receiving and verifying cross-chain messages. |
+| Blocked Message Library | `0xc1ce56b2099ca68720592583c7984cab4b6d7e7a` | Safety library for blocking misconfigured or invalid message paths. |
+| LZ Executor | `0x4208D6E27538189bB48E603D6123A94b8Abe0A0b` | Executes verified messages on Kite AI with a defined gas limit and msg.value. |
+| LZ Dead DVN | `0x6788f52439ACA6BFF597d3eeC2DC9a44B8FEE842` | Placeholder DVN used when default configs are inactive and manual configuration is required. |
 
 To check whether a destination chain is supported, use the `isSupportedEid()` method on the Endpoint contract.
 

--- a/kite-chain/12-lucid-kite-integration/README.md
+++ b/kite-chain/12-lucid-kite-integration/README.md
@@ -113,6 +113,13 @@ Each Kite asset has a dedicated lock contract that holds native USDC on a select
 * **Token on Avalanche:** `0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB`
 * **Token on KiteAI:** `0x3D66d6c3201190952e8EA973F59c4428b32D5F9b`
 
+#### USDT
+
+* **Controller:** `0x80bA7204f060Fd321BFE8d4F3aB2E2bF4e6fCe49`
+* **Deployed Chains:** Celo, KiteAI
+* **Activated bridge adapters:** LayerZero
+* **Token on KiteAI:** `0x3Fdd283C4c43A60398bf93CA01a8a8BD773a755b`
+
 For technical details, please visit [Lucid Labs documentation](https://docs.lucidlabs.fi/developer-reference/deployed-contracts/controller-contracts#kiteai-chain-id-2366).
 
 ## Summary

--- a/kite-chain/3-developing/smart-contracts-list.md
+++ b/kite-chain/3-developing/smart-contracts-list.md
@@ -1,84 +1,113 @@
-# Kite Protocol Smart Contracts
+# Kite Mainnet Contracts List
 
-This repository contains all smart contract implementations for the Kite Protocol, organized into the following main modules:
+This page provides a comprehensive list of all smart contracts deployed on Kite Mainnet and related cross-chain deployments.
 
-## Directory Structure
+---
 
-### bridge - Via Protocol Bridge Integration
-Implementation of integration with Via Protocol cross-chain bridge:
+## 1. Validator Staking Contracts
 
-**Contract Name: MessageClient.sol**
+Contracts that manage validator/delegator staking, reward calculation, and reward distribution on the Kite L1.
 
-**Description:** Cross-chain message handling client that facilitates communication between different blockchain networks through the Via Protocol bridge infrastructure.
 
-**Use Cases:**
-* Cross-Chain Communication: Enabling message passing between different blockchain networks
-* Bridge Integration: Providing standardized interface for Via Protocol bridge operations
-* Multi-Chain Coordination: Supporting coordinated actions across multiple blockchain networks
+| Contract                   | Address                                      | Description                                                                                                                                                               |
+| -------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| KiteStakingManager (Proxy) | `0x7d627b0F5Ec62155db013B8E7d1Ca9bA53218E82` | Upgradeable proxy for the staking manager. Entry point for validator registration, delegator staking, reward claims, and all staking operations.                          |
+| KiteStakingManager (Impl)  | `0x065cA4309a5abc9F1cC2d8fA00634BC948C25C6b` | Implementation contract behind the KiteStakingManager proxy. Contains the core staking logic for native KITE token staking.                                               |
+| RewardVault                | `0xd26850d11e8412fC6035750BE6A871dff9091FAe` | Holds native KITE tokens reserved for staking reward distribution. The staking manager calls `distributeReward()` to pay out validator/delegator rewards from this vault. |
+| FixedAPRRewardCalculator   | `0x171eefa30E88f9bca456CEf49c5Df093A516C7c2` | Calculates staking rewards using a fixed APR (simple interest). Reward formula: `stakeAmount * APR * uptimeSeconds / secondsInYear`. Current rate: 2.5% (250 bps).        |
+| ValidatorMessages          | `0x9C00629cE712B0255b17A4a657171Acd15720B8C` | Library contract for packing/unpacking ICM (Inter-Chain Messaging) messages used by the validator manager, as specified in ACP-77.                                        |
+| ProxyAdmin                 | `0x3FA7667FD726F73ef42c66f8715E0C6d37D44905` | OpenZeppelin ProxyAdmin that manages the KiteStakingManager proxy upgrades. Only the ProxyAdmin owner can trigger implementation upgrades.                                |
 
-**Contract Name: BridgedToken.sol**
 
-**Description:** Cross-chain token contract that represents tokens bridged from other networks, maintaining proper accounting and enabling seamless cross-chain token transfers.
+---
 
-**Use Cases:**
-* Cross-Chain Token Representation: Representing tokens from origin chains on destination networks
-* Bridge Token Management: Handling minting and burning of bridged tokens
-* Cross-Chain Asset Transfer: Enabling users to move assets between supported blockchain networks
+## 2. Staking Vault (LST) Contracts
 
-**Contract Name: ERC20Adapter.sol**
+Contracts for the liquid staking vault, enabling users to stake KITE and receive liquid staking tokens (LST).
 
-**Description:** ERC20 token adapter that provides standardized interface for bridging ERC20 tokens across different blockchain networks.
 
-**Use Cases:**
-* ERC20 Bridge Integration: Standardizing ERC20 token bridging operations
-* Token Standard Compatibility: Ensuring bridged tokens maintain ERC20 compliance
-* Cross-Chain ERC20 Support: Enabling any ERC20 token to be bridged through the Via Protocol
+| Contract                      | Address                                      | Description                                                                                                                           |
+| ----------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| StakingVault (Proxy)          | `0x23f7b52E2830C66f88EFc1f35b8a6a4AAe218dCA` | Upgradeable proxy for the staking vault. User-facing entry point for depositing KITE and receiving LST tokens.                        |
+| StakingVault (Impl)           | `0x69379f875551A505d77876a9363BcDe3dfd00bbe` | Implementation contract for the StakingVault proxy. Contains the core vault logic (deposit, withdraw, share accounting).              |
+| StakingVaultOperations (Impl) | `0xE31b845a6898D165e3dFc2AD4C3D61fE74394817` | Implementation contract handling operational logic for the staking vault (e.g., delegating staked assets to validators, rebalancing). |
 
-**Contract Name: NativeAdapter.sol**
 
-**Description:** Native token adapter for handling native blockchain tokens (like KITE, ETH, BNB) in cross-chain bridge operations.
+---
 
-**Use Cases:**
-* Native Token Bridging: Supporting cross-chain transfer of native blockchain tokens
-* Gas Token Management: Handling native tokens used for transaction fees across chains
-* Native Asset Integration: Providing bridge support for blockchain-native assets
+## 3. Tokens on Kite Mainnet
 
-### aa - Kite Smart Wallet Contracts
-Implementation of ERC-4337 Account Abstraction smart wallet system:
 
-#### Core Components
+| Token  | Address                                      | Decimals | Description                                                                                                    |
+| ------ | -------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| WKITE  | `0xcc788DC0486CD2BaacFf287eea1902cc09FbA570` | 18       | Wrapped KITE (ERC-20 wrapper for the native KITE token). Used for DEX trading and DeFi interactions.           |
+| USDC.e | `0x7aB6f3ed87C42eF0aDb67Ed95090f8bF5240149e` | 6        | Bridged USDC stablecoin (deployed and maintained by Lucid Labs). Used for payments, x402 settlement, and DeFi. |
+| USDT   | `0x3Fdd283C4c43A60398bf93CA01a8a8BD773a755b` | 6        | Bridged USDT stablecoin (deployed and maintained by Lucid Labs).                                               |
+| WETH   | `0x3D66d6c3201190952e8EA973F59c4428b32D5F9b` | 18       | Bridged Wrapped Ether (deployed by Lucid Labs).                                                                |
 
-**Contract Name: GokiteAccount.sol**
-**Contract Address:** `0x93F5310eFd0f09db0666CA5146E63CA6Cdc6FC21`
 
-**Description:** Main smart wallet contract implementing ERC-4337 Account Abstraction standard. This contract provides advanced wallet functionality including programmable transaction logic, social recovery, and gasless transactions.
+---
 
-**Use Cases:**
-* Account Abstraction: Providing smart contract wallet functionality with programmable logic
-* Gasless Transactions: Enabling users to interact with dApps without holding native tokens for gas
-* Advanced Security Features: Supporting multi-signature operations, social recovery, and custom authorization logic
-* User Experience Enhancement: Simplifying blockchain interactions through improved wallet functionality
+## 4. Algebra DEX Contracts
 
-**Contract Name: GokiteAccountFactory.sol**
-**Contract Address:** `0xF0Fc19F0dc393867F19351d25EDfc5E099561cb7`
+Algebra Integral concentrated liquidity DEX deployed on Kite Mainnet.
 
-**Description:** Factory contract for deterministic account creation, enabling predictable smart wallet addresses and efficient deployment of new wallet instances.
 
-**Use Cases:**
-* Deterministic Wallet Creation: Generating wallet addresses that can be predicted before deployment
-* Efficient Wallet Deployment: Streamlining the process of creating new smart wallet instances
-* Address Prediction: Allowing applications to know wallet addresses before actual deployment
-* Batch Wallet Operations: Supporting efficient creation of multiple wallet instances
+| Contract                   | Address                                      | Description                                                                      |
+| -------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------- |
+| AlgebraFactory             | `0x10253594A832f967994b44f33411940533302ACb` | Factory contract that creates and manages Algebra liquidity pools.               |
+| AlgebraPoolDeployer        | `0xd7cB0E0692f2D55A17bA81c1fE5501D66774fC4A` | Used by the factory to deploy individual pool contracts via CREATE2.             |
+| SwapRouter                 | `0x03f8B4b140249Dc7B2503C928E7258CCe1d91F1A` | Router for executing token swaps against Algebra pools.                          |
+| NonfungiblePositionManager | `0xD637cbc214Bc3dD354aBb309f4fE717ffdD0B28C` | Manages concentrated liquidity positions as NFTs (ERC-721).                      |
+| Multicall3                 | `0xE3104A157cc4C0d3c7C3a8c655092668D068c149` | Utility contract for batching multiple read/write calls in a single transaction. |
 
-## Kite App Store
 
-**Contract Name: ServiceRegistry**
-**Contract Address:** `0xc67a4AbcD8853221F241a041ACb1117b38DA587F`
+---
 
-**Description:** Service registry contract that manages and tracks various services within the Kite ecosystem. This contract stores comprehensive service information including service types, pricing models, unit prices, and other metadata necessary for service discovery and interaction.
+## 5. KITE Token (Cross-Chain)
 
-**Use Cases:**
-* Service Registration: Registering services with detailed information including service type, pricing model, and unit price
-* Service Management: Managing and updating service metadata, pricing information, and availability status
-* Service Discovery: Providing a registry for service lookup and interaction based on service type and pricing
-* Protocol Integration: Enabling seamless integration between different protocol components through standardized service metadata
+The KITE token deployed on external chains. All deployments are non-upgradeable with the same address across chains.
+
+
+| Network           | Address                                      |
+| ----------------- | -------------------------------------------- |
+| Ethereum Mainnet  | `0x904567252D8F48555b7447c67dCA23F0372E16be` |
+| BSC Mainnet       | `0x904567252D8F48555b7447c67dCA23F0372E16be` |
+| Avalanche C-Chain | `0x904567252D8F48555b7447c67dCA23F0372E16be` |
+
+
+---
+
+## 6. LayerZero Bridge Contracts
+
+LayerZero contracts for cross-chain messaging on Kite Mainnet.
+
+- **LayerZero Chain ID:** 2366
+- **LayerZero Endpoint ID:** 30406
+
+
+| Contract                | Address                                      |
+| ----------------------- | -------------------------------------------- |
+| EndpointV2              | `0x6F475642a6e85809B1c36Fa62763669b1b48DD5B` |
+| SendUln302              | `0xC39161c743D0307EB9BCc9FEF03eeb9Dc4802de7` |
+| ReceiveUln302           | `0xe1844c5D63a9543023008D332Bd3d2e6f1FE1043` |
+| LZ Executor             | `0x4208D6E27538189bB48E603D6123A94b8Abe0A0b` |
+| LZ Dead DVN             | `0x6788f52439ACA6BFF597d3eeC2DC9a44B8FEE842` |
+| Blocked Message Library | `0xc1ce56b2099ca68720592583c7984cab4b6d7e7a` |
+
+
+---
+
+## 7. Lucid Bridge Contracts
+
+Lucid contracts for cross-chain messaging on Kite Mainnet.
+
+
+| Contract                    | Address                                      |
+| --------------------------- | -------------------------------------------- |
+| USDC Controller (Avalanche) | `0x92E2391d0836e10b9e5EAB5d56BfC286Fadec25b` |
+| WETH Controller (Avalanche) | `0x638d1c70c7b047b192eB88657B411F84fAc74681` |
+| USDT Controller (Celo)      | `0x80bA7204f060Fd321BFE8d4F3aB2E2bF4e6fCe49` |
+| USDC Controller (Kite)      | `0x92E2391d0836e10b9e5EAB5d56BfC286Fadec25b` |
+| WETH Controller (Kite)      | `0x638d1c70c7b047b192eB88657B411F84fAc74681` |
+| USDT Controller (Kite)      | `0x80bA7204f060Fd321BFE8d4F3aB2E2bF4e6fCe49` |


### PR DESCRIPTION
## Summary
- Rewrote `smart-contracts-list.md` with comprehensive 7-section contract list covering validator staking, LST vault, tokens, Algebra DEX, cross-chain KITE token, LayerZero bridge, and Lucid bridge contracts
- Added contract addresses to LayerZero integration page
- Added USDT controller to Lucid integration page

## Test plan
- [ ] Verify all contract addresses render correctly in markdown tables
- [ ] Confirm links and formatting on GitBook/docs site