### PR TITLE
Add Passport wallet funding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,40 @@
 ---
-Description: >-
-  Kite is building the base layer for the agentic internet. It is the first
-  system that provides autonomous agents with cryptographic identity,
-  programmable permissions, and native access to stablecoin
+description: >-
+  Kite is building the base layer for the agentic internet — identity,
+  payments, and infrastructure for autonomous AI agents.
 ---
 
-# Quickstart
+# Kite Developer Docs
 
-> **The first AI payment blockchain** - foundational infrastructure empowering autonomous agents to operate and transact with identity, payment, governance, and verification.
+> **The first AI payment blockchain** — foundational infrastructure empowering autonomous agents to operate and transact with identity, payment, and verification.
 
-Choose your path to get started with Kite:
+## [Get Started](get-started/introduction-and-mission.md)
 
-### [Get Started](get-started/introduction-and-mission.md)
-
-**Why Kite?** - Learn about our mission, use cases, and core concepts
+Learn about Kite's mission, architecture, and core concepts.
 
 * [Introduction & Mission](get-started/introduction-and-mission.md)
 * [Key Use Cases & Players](get-started/key-use-cases-and-players.md)
 * [Architecture & Design Pillars](get-started/architecture-and-design-pillars.md)
 * [Core Concepts & Terminology](get-started/core-concepts-and-terminology.md)
 
-### [Kite Chain](kite-chain/1-getting-started/network-information.md)
+## [Kite Agent Passport](kite-agent-passport/README.md)
 
-**Build on Kite** - Network information, tools, and smart contract development
+Let your AI agent discover and pay for services on your behalf. Passport gives agents a funded wallet, scoped spending sessions, and service discovery — while you stay in control.
 
-* [ Information](kite-chain/1-getting-started/network-information.md)
+* [Getting Started](kite-agent-passport/README.md)
+* [Funding Your Wallet](kite-agent-passport/funding.md)
+* [CLI Reference](kite-agent-passport/cli-reference.md)
+* [Service Provider Guide](kite-agent-passport/service-provider-guide.md)
+
+## [Kite Chain](kite-chain/1-getting-started/network-information.md)
+
+Build on Kite — network information, tools, and smart contract development.
+
+* [Network Information](kite-chain/1-getting-started/network-information.md)
 * [Tools & Explorer](kite-chain/1-getting-started/tools.md)
 * [Smart Contract Development](kite-chain/3-developing/smart-contracts-list.md)
 * [Sample dApps](kite-chain/4-building-dapps/)
 
-### [Integration Guide](integration-guide/workflow-overview/)
+---
 
-Coming soon.
-
-## Key Features
-
-* **Cryptographic Identity**: 3-tier identity system for fine-grained governance
-* **Native Stablecoin Payments**: Built-in USDC support for instant settlements
-* **x402 Compatible:** Support for agent-to-agent (A2A) intents and verifiable message passing.
-* **Agent-First Design**: Purpose-built for autonomous agent operations
-* **Verifiable Delegation**: Cryptographic proof of payment authority
-* **High Performance**: Fast, scalable blockchain infrastructure
-
-## What's New
-
-* **Agentic Commerce**: Complete workflows for AI-powered shopping
-* **Smart Contract Templates**: Ready-to-use contracts for common use cases
-* **Developer Tools**: Comprehensive SDK and testing framework
-* **Security Best Practices**: Guidelines for secure agent integration
-
-
-## Github : Open an issue
-For any documentation updates or corrections, please [open an issue](https://github.com/gokite-ai/developer-docs/issues/new/choose) before submitting a PR, this helps us track and review changes efficiently.
-
-***
-
-_Ready to build the future of agentic commerce?_ [_Start with our Introduction_](get-started/introduction-and-mission.md)_._
+For any documentation updates or corrections, please [open an issue](https://github.com/gokite-ai/developer-docs/issues/new/choose).

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,16 +13,6 @@
 * [Tokenomics](get-started-why-kite/tokenomics.md)
 * [Whitepaper](get-started/whitepaper-references.md)
 
-## 🔗 Integration Guide
-
-* [Workflow Overview](integration-guide/workflow-overview/README.md)
-  * [Workflow A: Agent Builders](integration-guide/workflow-overview/workflow-a-agent-builders.md)
-  * [Workflow B: Merchants & Payment Providers](integration-guide/workflow-overview/workflow-b-merchants-and-payment-providers.md)
-* [SDK/API Overview for Developers](integration-guide/sdk-api-overview-for-developers/README.md)
-  * [Agent Builder Guide](integration-guide/sdk-api-overview-for-developers/agent-builder-guide.md)
-  * [Merchant Integration Guide](integration-guide/sdk-api-overview-for-developers/merchant-integration-guide.md)
-* [Case Study: App Store](integration-guide/case-study-app-store.md)
-
 
 ## ⛓️ Kite Agent Passport
 * [Introduction](kite-agent-passport/README.md)

--- a/kite-agent-passport/funding.md
+++ b/kite-agent-passport/funding.md
@@ -18,21 +18,13 @@ There are three ways to get funds into your Passport wallet:
 
 The simplest path if you are starting from zero. Purchase USDC directly into your Passport wallet using fiat currency.
 
-**Supported payment methods:**
-
-- Debit card
-- Credit card
-- Bank account
-
 **Steps:**
 
-1. Open the Passport dashboard.
-2. Go to the funding section.
-3. Select **Buy USDC**.
-4. Choose your payment method and amount.
-5. Set your Passport wallet as the destination — the dashboard pre-fills this for you.
-6. Complete the purchase.
-7. Wait for settlement — your balance will update automatically on the dashboard.
+1. Open the Passport dashboard and click **Buy**.
+2. Enter the amount you want to purchase.
+3. Click **Continue to Banxa** — you will be redirected to our on-ramp provider. Your Passport wallet address is filled in automatically.
+4. Follow the steps on Banxa to complete the purchase.
+5. Once the purchase settles, your balance will update on the Passport dashboard.
 
 ## Option 2: Bridge Directly to the Passport Wallet
 

--- a/kite-agent-passport/funding.md
+++ b/kite-agent-passport/funding.md
@@ -1,9 +1,97 @@
 ---
-description: How to fund your Kite Agent Passport wallet — on-ramp, transfers, and testnet faucet.
+description: How to fund your Kite Agent Passport wallet — buy USDC with fiat, bridge directly, or transfer from another wallet.
 ---
 
 # Funding Your Wallet
 
-> This page is coming soon. It will cover funding options in detail, including on-ramp providers, USDC transfers, and testnet faucet usage.
+To use Kite Agent Passport, you need **USDC on Kite chain** in your Passport wallet. All funding is managed through the **Passport dashboard**.
 
-For now, see the [Introduction](README.md) for a quick overview of funding paths.
+There are three ways to get funds into your Passport wallet:
+
+| Method | Best for |
+|---|---|
+| **Buy USDC with fiat** | Starting from scratch — pay with a card or bank account |
+| **Bridge directly to Passport** | You already hold tokens on another chain |
+| **Bridge to your wallet, then transfer** | You want funds in your own wallet first before moving to Passport |
+
+## Option 1: Buy USDC with Fiat
+
+The simplest path if you are starting from zero. Purchase USDC directly into your Passport wallet using fiat currency.
+
+**Supported payment methods:**
+
+- Debit card
+- Credit card
+- Bank account
+
+**Steps:**
+
+1. Open the Passport dashboard.
+2. Go to the funding section.
+3. Select **Buy USDC**.
+4. Choose your payment method and amount.
+5. Set your Passport wallet as the destination — the dashboard pre-fills this for you.
+6. Complete the purchase.
+7. Wait for settlement — your balance will update automatically on the dashboard.
+
+## Option 2: Bridge Directly to the Passport Wallet
+
+If you already hold tokens on another chain (Ethereum, Base, Arbitrum, etc.), you can bridge them directly into your Passport wallet on Kite chain. The bridge is not limited to stablecoins — you can bridge any token listed on [Kite Bridge](https://bridge.gokite.ai).
+
+**Steps:**
+
+1. Open the Passport dashboard and click the **Bridge** button — this opens [Kite Bridge](https://bridge.gokite.ai) with your Passport wallet address pre-filled as the destination.
+2. Connect the wallet that holds your funds.
+3. Select the source chain and token.
+4. Select Kite as the destination chain.
+5. Confirm both transaction popups.
+6. Wait 3–4 minutes for the bridge to complete.
+7. Your balance will update automatically on the Passport dashboard.
+
+You can also go to [bridge.gokite.ai](https://bridge.gokite.ai) directly and enter your Passport wallet address manually.
+
+This is the recommended path if you already hold crypto. Funds arrive in your Passport wallet ready to use — no additional steps needed.
+
+## Option 3: Bridge to Your Own Wallet, Then Transfer
+
+You can also bridge funds to your own wallet on Kite chain first, then transfer them to your Passport wallet. This gives you more control but requires extra steps.
+
+**What you need to know:**
+
+- You will need **KITE tokens** for gas fees on Kite chain to execute the transfer.
+- After bridging, your balance may not appear immediately in standard wallet interfaces — you may need to add the token contract on Kite chain to see it.
+
+**Steps:**
+
+1. Go to [Kite Bridge](https://bridge.gokite.ai) and bridge tokens from another chain to your own wallet on Kite chain. You can also reach the bridge from the **Bridge** button on the Passport dashboard — toggle off "Receive to the same address" to bridge to your own wallet instead.
+2. Make sure you also have KITE tokens in that wallet for gas.
+3. Add the token contract on Kite chain to your wallet if the balance is not visible.
+4. Open the Passport dashboard and copy your Passport wallet address.
+5. Send USDC from your wallet to the Passport wallet address.
+6. Confirm the transfer has landed on the dashboard.
+
+> This path is more involved than Options 1 and 2. Unless you have a specific reason to hold funds in your own wallet first, we recommend Option 1 or 2.
+
+## Checking Your Balance
+
+You can check your Passport wallet balance at any time:
+
+- **Dashboard** — the balance is shown on the main screen
+- **CLI** — run `kpass wallet balance`
+- **Ask your agent** — it can check the balance for you
+
+## Troubleshooting
+
+### Balance not showing after funding
+
+- **Bought with fiat** — settlement can take a few minutes depending on the payment provider. Check back on the dashboard.
+- **Bridged** — bridge times vary by source chain. Wait for the bridge transaction to confirm, then check the dashboard.
+- **Transferred from your own wallet** — make sure you sent to the correct Passport wallet address on Kite chain.
+
+### Need KITE tokens for gas (Option 3 only)
+
+If you are transferring from your own wallet on Kite chain, you need KITE tokens to pay gas. You can acquire KITE through supported exchanges or bridges.
+
+---
+
+*Need help? [Open an issue](https://github.com/gokite-ai/developer-docs/issues/new/choose) or contact the Kite team.*


### PR DESCRIPTION
## Summary

- **Funding guide** (`funding.md`): Replace placeholder with full guide covering three funding paths:
  1. Buy USDC with fiat via Banxa on-ramp
  2. Bridge directly to Passport wallet via [Kite Bridge](https://bridge.gokite.ai) — any listed token, not just stablecoins
  3. Bridge to your own wallet, then transfer (with KITE gas and token visibility caveats)
- **Top-level README**: Rewrite with three clear entry points — Get Started, Kite Agent Passport, Kite Chain. Remove stale Integration Guide, Key Features, and What's New sections.
- **SUMMARY.md**: Remove Integration Guide nav section.

## Test plan

- [ ] Verify funding page renders correctly on GitBook
- [ ] Confirm bridge.gokite.ai links resolve
- [ ] Review Banxa on-ramp flow accuracy with product team
- [ ] Verify top-level README navigation links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)