### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# CODEOWNERS for Kite developer-docs
-* @vikpande @vikkite @not-so-fat @springzh


### PR DESCRIPTION
## Summary

- Remove `.github/CODEOWNERS` so any org member with write access can approve and merge PRs
- Previously required review from 4 specific people on every PR, which is unnecessary for a docs repo

## After merging

- Check **Settings > Branches > main** — if "Require review from Code Owners" is enabled, uncheck it

🤖 Generated with [Claude Code](https://claude.com/claude-code)