### PR TITLE
docs: update mainnet RPC docs and gasless testnet PYUSD guide

### DIFF
--- a/kite-chain/1-getting-started/network-information.md
+++ b/kite-chain/1-getting-started/network-information.md
@@ -33,9 +33,18 @@ description: Chain IDs, endpoints, and environment details for Kite networks.
   * Token: KITE
   * Block Explorer URL - [https://kitescan.ai/](https://kitescan.ai/)
 
-### RPC endpoint
+### RPC endpoints
 
-* Mainnet - [https://rpc.gokite.ai/](https://rpc.gokite.ai/)
+* Mainnet HTTPS RPCs
+  * Global - [https://rpc.gokite.ai/](https://rpc.gokite.ai/)
+  * Virginia - [https://rpc-virginia.gokite.ai](https://rpc-virginia.gokite.ai)
+  * Tokyo - [https://rpc-tokyo.gokite.ai](https://rpc-tokyo.gokite.ai)
+  * Ireland - [https://rpc-ireland.gokite.ai](https://rpc-ireland.gokite.ai)
+* Mainnet WSS RPCs
+  * Global - [wss://rpc.gokite.ai/ws](wss://rpc.gokite.ai/ws)
+  * Virginia - [wss://rpc-virginia.gokite.ai/ws](wss://rpc-virginia.gokite.ai/ws)
+  * Tokyo - [wss://rpc-tokyo.gokite.ai/ws](wss://rpc-tokyo.gokite.ai/ws)
+  * Ireland - [wss://rpc-ireland.gokite.ai/ws](wss://rpc-ireland.gokite.ai/ws)
 
 ### ChainList link
 * Mainnet - [https://chainlist.org/chain/2366](https://chainlist.org/chain/2366)

--- a/kite-chain/7-kite-node/mainnet-network-information.md
+++ b/kite-chain/7-kite-node/mainnet-network-information.md
@@ -19,12 +19,16 @@ Kite Mainnet provides multiple geographically distributed RPC endpoints for reli
 It is recommended to configure **multiple RPCs** for redundancy in production environments.
 
 ### HTTPS RPCs
-- [https://rpc.gokite.ai/](https://rpc.gokite.ai/)
-- [https://rpc-virginia.gokite.ai](https://rpc-virginia.gokite.ai)
+- Global - [https://rpc.gokite.ai/](https://rpc.gokite.ai/)
+- Virginia - [https://rpc-virginia.gokite.ai](https://rpc-virginia.gokite.ai)
+- Tokyo - [https://rpc-tokyo.gokite.ai](https://rpc-tokyo.gokite.ai)
+- Ireland - [https://rpc-ireland.gokite.ai](https://rpc-ireland.gokite.ai)
 
 ### WebSocket (WSS) RPCs
-- [wss://rpc.gokite.ai/ws](wss://rpc.gokite.ai/ws)
-- [wss://rpc-virginia.gokite.ai/ws](wss://rpc-virginia.gokite.ai/ws)
+- Global - [wss://rpc.gokite.ai/ws](wss://rpc.gokite.ai/ws)
+- Virginia - [wss://rpc-virginia.gokite.ai/ws](wss://rpc-virginia.gokite.ai/ws)
+- Tokyo - [wss://rpc-tokyo.gokite.ai/ws](wss://rpc-tokyo.gokite.ai/ws)
+- Ireland - [wss://rpc-ireland.gokite.ai/ws](wss://rpc-ireland.gokite.ai/ws)
 
 WebSocket endpoints are recommended for:
 - Real-time event subscriptions

--- a/kite-chain/9-gasless-integration/README.md
+++ b/kite-chain/9-gasless-integration/README.md
@@ -24,6 +24,17 @@ Network selection is done via the request path:
 
 **Service endpoint** - `https://gasless.gokite.ai`
 
+## Testnet Token Claim
+
+For testnet integration and end-to-end testing, developers can mint testnet `PYUSD` themselves before submitting gasless transfer requests.
+
+The `PYUSD` token on Kite Testnet includes built-in `claim` and `claimTo` functions. The contract has been verified on Testnet Kitescan, so builders can:
+
+- Use the Kitescan contract page to call the write methods directly
+- Create and send `claim` or `claimTo` transactions from their own scripts or wallets
+
+**Testnet PYUSD contract:** [`0x8E04D099b1a8Dd20E6caD4b2Ab2B405B98242ec9`](https://testnet.kitescan.ai/address/0x8E04D099b1a8Dd20E6caD4b2Ab2B405B98242ec9?tab=read_write_contract)
+
 ## API Reference
 
 ### List Supported Tokens


### PR DESCRIPTION
## Summary

  This PR updates the Kite Chain docs to make mainnet RPC discovery clearer and reduce friction for gasless testing on testnet.

  ## Changes

  - add regional Kite Mainnet HTTPS RPC endpoints to the getting started network docs:
    - Global
    - Virginia
    - Tokyo
    - Ireland
  - add matching regional Kite Mainnet WSS RPC endpoints to the same docs
  - align the Mainnet Node Network Information page with the full regional RPC list
  - add a gasless integration note explaining that builders can mint testnet `PYUSD` themselves for testing
  - document that the testnet `PYUSD` contract includes built-in `claim` and `claimTo` functions
  - add the verified Testnet Kitescan contract link for direct interaction:
    - https://testnet.kitescan.ai/address/0x8E04D099b1a8Dd20E6caD4b2Ab2B405B98242ec9?tab=read_write_contract

  ## Why

  - makes regional RPC endpoints easier to find for wallet, node, and infra configuration
  - keeps the getting started and node docs consistent
  - gives builders a clear way to obtain testnet `PYUSD` before testing gasless transfer flows

  ## Testing

  - docs-only change
  - no tests run