### PR TITLE
feat: add GitBook deprecation banner to every page

### DIFF
--- a/.github/workflows/changelog-build.yml
+++ b/.github/workflows/changelog-build.yml
@@ -1,13 +1,7 @@
 name: Rebuild changelog index
 
 on:
-  pull_request:
-    paths:
-      - "changelog/**"
-  push:
-    branches: [main]
-    paths:
-      - "changelog/**"
+  workflow_dispatch:
 
 jobs:
   rebuild:

--- a/.github/workflows/changelog-commands.yml
+++ b/.github/workflows/changelog-commands.yml
@@ -1,7 +1,6 @@
 name: Changelog reviewer commands
 on:
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
   dispatch:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ description: >-
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ description: >-
   payments, and infrastructure for autonomous AI agents.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Kite Developer Docs
 
 > **The first AI payment blockchain** — foundational infrastructure empowering autonomous agents to operate and transact with identity, payment, and verification.

--- a/changelog/2026/2026-05-19-backend-v1-1-0.md
+++ b/changelog/2026/2026-05-19-backend-v1-1-0.md
@@ -14,7 +14,7 @@ corrected_at: null
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/changelog/2026/2026-05-19-backend-v1-1-0.md
+++ b/changelog/2026/2026-05-19-backend-v1-1-0.md
@@ -12,6 +12,12 @@ generated_at: 2026-05-19T18:00:00Z
 corrected_at: null
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## What changed
 
 When an agent constructs a session delegation, the preflight call now returns an `estimated_fees` object covering the catalog's known merchant fees, network gas, and Passport's own service margin. Approval pages can show users an itemized "up to ~$X" total instead of just a raw budget cap.

--- a/changelog/2026/2026-05-19-cli-v1-3-4.md
+++ b/changelog/2026/2026-05-19-cli-v1-3-4.md
@@ -14,7 +14,7 @@ corrected_at: null
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/changelog/2026/2026-05-19-cli-v1-3-4.md
+++ b/changelog/2026/2026-05-19-cli-v1-3-4.md
@@ -12,6 +12,12 @@ generated_at: 2026-05-19T18:00:00Z
 corrected_at: null
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## What changed
 
 The `kpass activity` command previously returned the full event history with no way to narrow the result set. Agents asking "what did I spend on Amazon last week?" had to fetch everything and filter locally, which was slow on accounts with many sessions.

--- a/changelog/2026/2026-05-19-skills-v0-9-1.md
+++ b/changelog/2026/2026-05-19-skills-v0-9-1.md
@@ -14,7 +14,7 @@ corrected_at: null
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/changelog/2026/2026-05-19-skills-v0-9-1.md
+++ b/changelog/2026/2026-05-19-skills-v0-9-1.md
@@ -12,6 +12,12 @@ generated_at: 2026-05-19T18:00:00Z
 corrected_at: null
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## What changed
 
 `request-session` previously treated any non-200 response from the catalog preflight as a hard failure, which meant transient catalog blips would abort otherwise-valid session approvals. The skill now retries 503 and timeout responses up to three times with exponential backoff before propagating the error.

--- a/changelog/2026/2026-05-19-web-v1-2-0.md
+++ b/changelog/2026/2026-05-19-web-v1-2-0.md
@@ -14,7 +14,7 @@ corrected_at: null
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/changelog/2026/2026-05-19-web-v1-2-0.md
+++ b/changelog/2026/2026-05-19-web-v1-2-0.md
@@ -12,6 +12,12 @@ generated_at: 2026-05-19T18:00:00Z
 corrected_at: null
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## What changed
 
 The session approval page now renders the new `estimated_fees` field from the backend preflight. Users see the budget cap and an itemized "up to ~$X" estimate covering merchant fees, network gas, and Passport's service margin.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Changelog
 
 Public delivery timeline for Kite Passport — see each component's recent releases below. Please be noticed this Changelog feature is still being processed and may change.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Development Setup
 
 This directory contains development and build tools for the Kite Documentation.

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/docs/STYLING_GUIDE.md
+++ b/docs/STYLING_GUIDE.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # 🎨 Kite Documentation - Modern Styling Guide
 
 ## Overview

--- a/docs/STYLING_GUIDE.md
+++ b/docs/STYLING_GUIDE.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started-why-kite/tokenomics.md
+++ b/get-started-why-kite/tokenomics.md
@@ -6,7 +6,7 @@ description: >-
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started-why-kite/tokenomics.md
+++ b/get-started-why-kite/tokenomics.md
@@ -4,6 +4,12 @@ description: >-
   AI economy
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Tokenomics
 
 ### The Mission of Kite AI

--- a/get-started/README.md
+++ b/get-started/README.md
@@ -2,6 +2,12 @@
 description: Get started with Kite - learn about our mission, use cases, architecture, and core concepts that make Kite the first AI payment blockchain.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # 🎯 Get Started with Kite
 
 Welcome to Kite - the first AI payment blockchain. This section will help you understand why Kite exists, what problems it solves, and how it works.

--- a/get-started/README.md
+++ b/get-started/README.md
@@ -4,7 +4,7 @@ description: Get started with Kite - learn about our mission, use cases, archite
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started/architecture-and-design-pillars.md
+++ b/get-started/architecture-and-design-pillars.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started/architecture-and-design-pillars.md
+++ b/get-started/architecture-and-design-pillars.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Architecture & Design Pillars
 
 Kite is built from first principles for autonomous agents, not adapted from human-centric systems. Every architectural decision optimizes for one goal: enabling agents to operate with mathematical safety guarantees.

--- a/get-started/core-concepts-and-terminology.md
+++ b/get-started/core-concepts-and-terminology.md
@@ -2,6 +2,12 @@
 description: Core concepts and terminology for Kite's agent-native infrastructure
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Core Concepts & Terminology
 
 Essential building blocks that enable autonomous agent operations in Kite's ecosystem.

--- a/get-started/core-concepts-and-terminology.md
+++ b/get-started/core-concepts-and-terminology.md
@@ -4,7 +4,7 @@ description: Core concepts and terminology for Kite's agent-native infrastructur
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started/introduction-and-mission.md
+++ b/get-started/introduction-and-mission.md
@@ -7,7 +7,7 @@ description: >-
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started/introduction-and-mission.md
+++ b/get-started/introduction-and-mission.md
@@ -5,6 +5,12 @@ description: >-
   and verification.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Introduction & Mission
 
 #### Current State of Internet <a href="#current-state-of-internet" id="current-state-of-internet"></a>

--- a/get-started/key-use-cases-and-players.md
+++ b/get-started/key-use-cases-and-players.md
@@ -4,7 +4,7 @@ description: Key use cases and players in the agentic economy enabled by Kite's 
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/get-started/key-use-cases-and-players.md
+++ b/get-started/key-use-cases-and-players.md
@@ -2,6 +2,12 @@
 description: Key use cases and players in the agentic economy enabled by Kite's infrastructure
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Key Use Cases & Players
 
 ## Retail: Agentic Commerce

--- a/get-started/whitepaper-references.md
+++ b/get-started/whitepaper-references.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Whitepaper
 
 Explore our technical and research papers that describe the foundations of Kite.

--- a/get-started/whitepaper-references.md
+++ b/get-started/whitepaper-references.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/README.md
+++ b/integration-guide/README.md
@@ -2,6 +2,12 @@
 description: Complete integration guide for Kite - learn how to build AI agents that make payments and integrate Kite's payment infrastructure into your applications.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # 🔗 Integration Guide
 
 This section provides workflows for integrating with Kite with example, whether you're building AI agents that make payments or services that receive payments from agents.

--- a/integration-guide/README.md
+++ b/integration-guide/README.md
@@ -4,7 +4,7 @@ description: Complete integration guide for Kite - learn how to build AI agents 
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/api-agent-builder-guide.md
+++ b/integration-guide/api-agent-builder-guide.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/api-agent-builder-guide.md
+++ b/integration-guide/api-agent-builder-guide.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Agent Builder Guide
 
 Complete guide for building AI agents with Kite's payment capabilities - agent registration and payment integration.

--- a/integration-guide/api-merchants-payment-providers.md
+++ b/integration-guide/api-merchants-payment-providers.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/api-merchants-payment-providers.md
+++ b/integration-guide/api-merchants-payment-providers.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Merchant Integration Guide
 
 Integrate Kite’s payment verification API into your checkout system to accept **agent-initiated stablecoin payments** with full proof-based security.

--- a/integration-guide/api-references.md
+++ b/integration-guide/api-references.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # SDK/API Overview
 
 SDK/API overview of how to integrate with Kite's agentic payment infrastructure.

--- a/integration-guide/api-references.md
+++ b/integration-guide/api-references.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/case-study-app-store.md
+++ b/integration-guide/case-study-app-store.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Case Study: App Store
 

--- a/integration-guide/case-study-app-store.md
+++ b/integration-guide/case-study-app-store.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/sdk-api-overview-for-developers/README.md
+++ b/integration-guide/sdk-api-overview-for-developers/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/sdk-api-overview-for-developers/README.md
+++ b/integration-guide/sdk-api-overview-for-developers/README.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # SDK/API Overview for Developers
 

--- a/integration-guide/sdk-api-overview-for-developers/agent-builder-guide.md
+++ b/integration-guide/sdk-api-overview-for-developers/agent-builder-guide.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/sdk-api-overview-for-developers/agent-builder-guide.md
+++ b/integration-guide/sdk-api-overview-for-developers/agent-builder-guide.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Agent Builder Guide
 

--- a/integration-guide/sdk-api-overview-for-developers/merchant-integration-guide.md
+++ b/integration-guide/sdk-api-overview-for-developers/merchant-integration-guide.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Merchant Integration Guide
 

--- a/integration-guide/sdk-api-overview-for-developers/merchant-integration-guide.md
+++ b/integration-guide/sdk-api-overview-for-developers/merchant-integration-guide.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/workflow-agent-builders.md
+++ b/integration-guide/workflow-agent-builders.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/workflow-agent-builders.md
+++ b/integration-guide/workflow-agent-builders.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## Workflow A: Agent Builders
 
 ### End-user workflow

--- a/integration-guide/workflow-merchants-payment-providers.md
+++ b/integration-guide/workflow-merchants-payment-providers.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## Workflow B: Merchants & Payment Providers
 
 ### Merchant workflow

--- a/integration-guide/workflow-merchants-payment-providers.md
+++ b/integration-guide/workflow-merchants-payment-providers.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/workflow-overview.md
+++ b/integration-guide/workflow-overview.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 ## Workflow Overview
 
 ### Example: Agentic Commerce

--- a/integration-guide/workflow-overview.md
+++ b/integration-guide/workflow-overview.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/workflow-overview/README.md
+++ b/integration-guide/workflow-overview/README.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Workflow Overview
 

--- a/integration-guide/workflow-overview/README.md
+++ b/integration-guide/workflow-overview/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/workflow-overview/workflow-a-agent-builders.md
+++ b/integration-guide/workflow-overview/workflow-a-agent-builders.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Workflow A: Agent Builders
 

--- a/integration-guide/workflow-overview/workflow-a-agent-builders.md
+++ b/integration-guide/workflow-overview/workflow-a-agent-builders.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/integration-guide/workflow-overview/workflow-b-merchants-and-payment-providers.md
+++ b/integration-guide/workflow-overview/workflow-b-merchants-and-payment-providers.md
@@ -1,2 +1,8 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Workflow B: Merchants & Payment Providers
 

--- a/integration-guide/workflow-overview/workflow-b-merchants-and-payment-providers.md
+++ b/integration-guide/workflow-overview/workflow-b-merchants-and-payment-providers.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/README.md
+++ b/kite-agent-passport/README.md
@@ -2,6 +2,12 @@
 description: Get started with Kite Agent Passport — let your AI agent discover and pay for services on your behalf.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Kite Agent Passport
 
 Kite Agent Passport lets your AI agent discover and pay for services on your behalf. You stay in control of what it can spend — the agent handles everything else.

--- a/kite-agent-passport/README.md
+++ b/kite-agent-passport/README.md
@@ -4,7 +4,7 @@ description: Get started with Kite Agent Passport — let your AI agent discover
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/add-kite-tokens-external-wallet.md
+++ b/kite-agent-passport/add-kite-tokens-external-wallet.md
@@ -2,6 +2,12 @@
 description: Step-by-step instructions for adding KITE tokens to your external wallet.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Add Kite Tokens to an External Wallet
 
 If you need to access KITE tokens or USDC.e in your external wallet (e.g., MetaMask), you will need to add Kite Network information to your wallet.

--- a/kite-agent-passport/add-kite-tokens-external-wallet.md
+++ b/kite-agent-passport/add-kite-tokens-external-wallet.md
@@ -4,7 +4,7 @@ description: Step-by-step instructions for adding KITE tokens to your external w
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/beginner-setup.md
+++ b/kite-agent-passport/beginner-setup.md
@@ -2,6 +2,12 @@
 description: Full installation walkthrough for choosing an agent, installing Kite Agent Passport, creating your Passport account, and approving your first session.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Full Installation Walkthrough
 
 This guide is for users who are new to coding agents or Kite Agent Passport. You will set up an agent that can run commands, install Passport, create your Passport account, set up your passkey, and approve your first spending session.

--- a/kite-agent-passport/beginner-setup.md
+++ b/kite-agent-passport/beginner-setup.md
@@ -4,7 +4,7 @@ description: Full installation walkthrough for choosing an agent, installing Kit
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/cli-reference.md
+++ b/kite-agent-passport/cli-reference.md
@@ -4,7 +4,7 @@ description: CLI reference for kpass and ksearch — all commands for Kite Agent
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/cli-reference.md
+++ b/kite-agent-passport/cli-reference.md
@@ -2,6 +2,12 @@
 description: CLI reference for kpass and ksearch — all commands for Kite Agent Passport.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # CLI Reference
 
 This page documents the `kpass` and `ksearch` commands. For getting started, see the [Introduction](README.md).

--- a/kite-agent-passport/funding.md
+++ b/kite-agent-passport/funding.md
@@ -4,7 +4,7 @@ description: How to fund your Kite Agent Passport wallet — buy USDC with fiat,
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/funding.md
+++ b/kite-agent-passport/funding.md
@@ -2,6 +2,12 @@
 description: How to fund your Kite Agent Passport wallet — buy USDC with fiat, bridge directly, or transfer from another wallet.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Funding Your Wallet
 
 To use Kite Agent Passport, you need **USDC on Kite chain** in your Passport wallet. All funding is managed through the **Passport dashboard**.

--- a/kite-agent-passport/service-provider-guide.md
+++ b/kite-agent-passport/service-provider-guide.md
@@ -4,7 +4,7 @@ description: Guide for service providers to accept payments from Kite Agent Pass
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-agent-passport/service-provider-guide.md
+++ b/kite-agent-passport/service-provider-guide.md
@@ -2,6 +2,12 @@
 description: Guide for service providers to accept payments from Kite Agent Passport agents via x402 or MPP.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Service Provider Guide
 
 Kite Agent Passport can pay any service that implements one of two open payment protocols:

--- a/kite-chain/1-getting-started/README.md
+++ b/kite-chain/1-getting-started/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/1-getting-started/README.md
+++ b/kite-chain/1-getting-started/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Getting Started with Kite Chain
 
 Welcome to Kite Chain! This section provides everything you need to start building on Kite's blockchain network.

--- a/kite-chain/1-getting-started/faqs.md
+++ b/kite-chain/1-getting-started/faqs.md
@@ -2,6 +2,12 @@
 description: Frequently Asked Questions
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # FAQs
 
 <details>

--- a/kite-chain/1-getting-started/faqs.md
+++ b/kite-chain/1-getting-started/faqs.md
@@ -4,7 +4,7 @@ description: Frequently Asked Questions
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/1-getting-started/network-information.md
+++ b/kite-chain/1-getting-started/network-information.md
@@ -4,7 +4,7 @@ description: Chain IDs, endpoints, and environment details for Kite networks.
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/1-getting-started/network-information.md
+++ b/kite-chain/1-getting-started/network-information.md
@@ -2,6 +2,12 @@
 description: Chain IDs, endpoints, and environment details for Kite networks.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Network Information
 
 ## Kite network settings (testnet)

--- a/kite-chain/1-getting-started/tools.md
+++ b/kite-chain/1-getting-started/tools.md
@@ -4,7 +4,7 @@ description: Explorers, wallets, and references for building on Kite.
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/1-getting-started/tools.md
+++ b/kite-chain/1-getting-started/tools.md
@@ -2,6 +2,12 @@
 description: Explorers, wallets, and references for building on Kite.
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Tools
 
 ## Kite tools

--- a/kite-chain/10-layerzero-kite-integration/README.md
+++ b/kite-chain/10-layerzero-kite-integration/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # LayerZero Integration on Kite AI
 
 LayerZero is natively supported on Kite AI Mainnet, enabling secure omnichain messaging, asset transfers, and cross-chain application composition. This page provides architectural context and operational guidance for developers building cross-chain applications on Kite AI using LayerZero v2.

--- a/kite-chain/10-layerzero-kite-integration/README.md
+++ b/kite-chain/10-layerzero-kite-integration/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/11-goldsky-kite-integration/README.md
+++ b/kite-chain/11-goldsky-kite-integration/README.md
@@ -2,6 +2,12 @@
 description: Index Kite AI with Goldsky for high-performance blockchain data infrastructure
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Indexing Kite AI with Goldsky
 
 ## Overview

--- a/kite-chain/11-goldsky-kite-integration/README.md
+++ b/kite-chain/11-goldsky-kite-integration/README.md
@@ -4,7 +4,7 @@ description: Index Kite AI with Goldsky for high-performance blockchain data inf
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/12-lucid-kite-integration/README.md
+++ b/kite-chain/12-lucid-kite-integration/README.md
@@ -4,7 +4,7 @@ description: Kite Integration with Lucid - Native yield-generating USDC liquidit
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/12-lucid-kite-integration/README.md
+++ b/kite-chain/12-lucid-kite-integration/README.md
@@ -2,6 +2,12 @@
 description: Kite Integration with Lucid - Native yield-generating USDC liquidity for the Kite ecosystem
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Kite Integration with Lucid
 
 Lucid has integrated with Kite to bring native yield-generating stablecoin liquidity (USDC) to the Kite ecosystem. This integration enables developers, apps, and ecosystem partners to use canonical, cross-chain stablecoins that automatically generate yield while remaining fully redeemable across supported networks.

--- a/kite-chain/2-fundamentals/README.md
+++ b/kite-chain/2-fundamentals/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/2-fundamentals/README.md
+++ b/kite-chain/2-fundamentals/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Blockchain Fundamentals
 
 If you're new to blockchain development, this section covers the foundational concepts you need to understand before building on Kite Chain.

--- a/kite-chain/2-fundamentals/blockchain-fundamentals.md
+++ b/kite-chain/2-fundamentals/blockchain-fundamentals.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Blockchain Fundamentals
 
 ## What is a Blockchain?

--- a/kite-chain/2-fundamentals/blockchain-fundamentals.md
+++ b/kite-chain/2-fundamentals/blockchain-fundamentals.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/2-fundamentals/smart-contract-basics.md
+++ b/kite-chain/2-fundamentals/smart-contract-basics.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/2-fundamentals/smart-contract-basics.md
+++ b/kite-chain/2-fundamentals/smart-contract-basics.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Smart Contract Basics
 
 ## Introduction

--- a/kite-chain/3-developing/README.md
+++ b/kite-chain/3-developing/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/3-developing/README.md
+++ b/kite-chain/3-developing/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Developing Smart Contracts
 
 Learn how to write, deploy, and interact with smart contracts on Kite Chain using industry-standard tools.

--- a/kite-chain/3-developing/counter-smart-contract-hardhat.md
+++ b/kite-chain/3-developing/counter-smart-contract-hardhat.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 Build & Deploy a Counter Contract on Kite AI using Hardhat
 
 What is Hardhat?

--- a/kite-chain/3-developing/counter-smart-contract-hardhat.md
+++ b/kite-chain/3-developing/counter-smart-contract-hardhat.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/3-developing/counter-smart-contract-remix.md
+++ b/kite-chain/3-developing/counter-smart-contract-remix.md
@@ -4,7 +4,7 @@ description: Building & deploying a smart contract on KITE AI with Remix
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/3-developing/counter-smart-contract-remix.md
+++ b/kite-chain/3-developing/counter-smart-contract-remix.md
@@ -2,6 +2,12 @@
 description: Building & deploying a smart contract on KITE AI with Remix
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Counter Smart contract
 
 Please follow the below steps to build your smart contract on Kite AI:

--- a/kite-chain/3-developing/setup-environment.md
+++ b/kite-chain/3-developing/setup-environment.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Building on Kite Chain - Network setting & tools 
 
 Before we start building smart contracts on Kite, its important to go over this section which is designed to help developers quickly set up all the critical tools required for building on the Kite blockchain. Whether you’re a beginner taking your first steps into Web3 development or an experienced EVM builder looking to dive into advanced integrations, this guide provides the tools, resources, and best practices you need to succeed. 

--- a/kite-chain/3-developing/setup-environment.md
+++ b/kite-chain/3-developing/setup-environment.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/3-developing/smart-contracts-list.md
+++ b/kite-chain/3-developing/smart-contracts-list.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/3-developing/smart-contracts-list.md
+++ b/kite-chain/3-developing/smart-contracts-list.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Kite Mainnet Contracts List
 
 This page provides a comprehensive list of all smart contracts deployed on Kite Mainnet and related cross-chain deployments.

--- a/kite-chain/3-developing/voting-smart-contract.md
+++ b/kite-chain/3-developing/voting-smart-contract.md
@@ -4,7 +4,7 @@ description: Building & deploying a smart contract on KITE AI with Remix
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/3-developing/voting-smart-contract.md
+++ b/kite-chain/3-developing/voting-smart-contract.md
@@ -2,6 +2,12 @@
 description: Building & deploying a smart contract on KITE AI with Remix
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Voting Smart contract
 
 Please follow the below steps to build your smart contract on Kite AI:

--- a/kite-chain/4-building-dapps/README.md
+++ b/kite-chain/4-building-dapps/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Building dApps
 
 Learn how to build complete decentralized applications (dApps) with React frontends that interact with your smart contracts.

--- a/kite-chain/4-building-dapps/README.md
+++ b/kite-chain/4-building-dapps/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/4-building-dapps/counter-dapp.md
+++ b/kite-chain/4-building-dapps/counter-dapp.md
@@ -4,7 +4,7 @@ description: A sample counter dApp built with KITE AI testnet & React
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/4-building-dapps/counter-dapp.md
+++ b/kite-chain/4-building-dapps/counter-dapp.md
@@ -2,6 +2,12 @@
 description: A sample counter dApp built with KITE AI testnet & React
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Counter dApp
 
 ## Building the dApp with React

--- a/kite-chain/4-building-dapps/token-minter.md
+++ b/kite-chain/4-building-dapps/token-minter.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/4-building-dapps/token-minter.md
+++ b/kite-chain/4-building-dapps/token-minter.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Token Minter
 
 ## Deploying an ERC-20 Token on the KiteAI Testnet

--- a/kite-chain/4-building-dapps/voting-dapp.md
+++ b/kite-chain/4-building-dapps/voting-dapp.md
@@ -2,6 +2,12 @@
 description: A sample voting dApp built with KITE AI testnet & React
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Voting dApp
 
 ## Building the dApp with React

--- a/kite-chain/4-building-dapps/voting-dapp.md
+++ b/kite-chain/4-building-dapps/voting-dapp.md
@@ -4,7 +4,7 @@ description: A sample voting dApp built with KITE AI testnet & React
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/5-advanced/README.md
+++ b/kite-chain/5-advanced/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/5-advanced/README.md
+++ b/kite-chain/5-advanced/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Advanced Features
 
 Take your Kite Chain development to the next level with advanced blockchain features and tools.

--- a/kite-chain/5-advanced/account-abstraction-sdk.md
+++ b/kite-chain/5-advanced/account-abstraction-sdk.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # GoKite Account Abstraction SDK – Developer Guide
 
 The GoKite Account Abstraction (AA) SDK enables developers to build smart contract wallets, manage transactions, and implement rule-based agent spending on the Kite AI Layer 1 chain using ERC-4337 Account Abstraction principles. 

--- a/kite-chain/5-advanced/account-abstraction-sdk.md
+++ b/kite-chain/5-advanced/account-abstraction-sdk.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/5-advanced/multisig-wallet.md
+++ b/kite-chain/5-advanced/multisig-wallet.md
@@ -2,6 +2,12 @@
 description: Ash Multisig Wallet for Kite AI L1
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Multisig Wallet
 
 A Safe-style technical guide for GoKite.ai builders & operators that bring all the features of Safe to Kite L1 & Avalanche ecosystem. The Support includes contract deployment, gas estimation, and contract-powered multisig.

--- a/kite-chain/5-advanced/multisig-wallet.md
+++ b/kite-chain/5-advanced/multisig-wallet.md
@@ -4,7 +4,7 @@ description: Ash Multisig Wallet for Kite AI L1
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/6-reference.md
+++ b/kite-chain/6-reference.md
@@ -4,7 +4,7 @@ description: Kite Security, a secure-by-design and DevSecOps-driven approach
 
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/6-reference.md
+++ b/kite-chain/6-reference.md
@@ -2,6 +2,12 @@
 description: Kite Security, a secure-by-design and DevSecOps-driven approach
 ---
 
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Security at Kite
 
 ## Security at Kite&#x20;

--- a/kite-chain/7-kite-node/README.md
+++ b/kite-chain/7-kite-node/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/7-kite-node/README.md
+++ b/kite-chain/7-kite-node/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Kite Node
 
 This page contains documentation and operational guidance for running and managing nodes on the Kite mainnet.

--- a/kite-chain/7-kite-node/mainnet-network-information.md
+++ b/kite-chain/7-kite-node/mainnet-network-information.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Mainnet Network Information
 
 This page provides the essential network details required to connect to and interact with the **Kite Mainnet**.  

--- a/kite-chain/7-kite-node/mainnet-network-information.md
+++ b/kite-chain/7-kite-node/mainnet-network-information.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/7-kite-node/mainnet-node-operations.md
+++ b/kite-chain/7-kite-node/mainnet-node-operations.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/7-kite-node/mainnet-node-operations.md
+++ b/kite-chain/7-kite-node/mainnet-node-operations.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Mainnet Node Operations
 
 This page describes how to set up, configure, deploy, and operate a Kite mainnet node.

--- a/kite-chain/8-kite-stablecoin/stablecoin-gasless-transfer.md
+++ b/kite-chain/8-kite-stablecoin/stablecoin-gasless-transfer.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Stablecoin workflow and User Experience
 
 This section describes how users interact with Kite Chain tokens under both **normal (gas-paid)** and **gasless (meta-transaction)** transfer flows, along with the backend API interface, integration scenarios, reference smart contract implementation, and security considerations.

--- a/kite-chain/8-kite-stablecoin/stablecoin-gasless-transfer.md
+++ b/kite-chain/8-kite-stablecoin/stablecoin-gasless-transfer.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/9-gasless-integration/README.md
+++ b/kite-chain/9-gasless-integration/README.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # Stablecoin Gasless Transfer: Integration Guide
 
 This page provides practical integration instructions for using Kite's Stablecoin Gasless Transfer service. It is intended for developers who want to implement gasless token transfers using signed authorizations (EIP-3009).

--- a/kite-chain/9-gasless-integration/README.md
+++ b/kite-chain/9-gasless-integration/README.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/kite-chain/mica-whitepaper.md
+++ b/kite-chain/mica-whitepaper.md
@@ -1,3 +1,9 @@
+<!-- DEPRECATION-BANNER:START -->
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+<!-- DEPRECATION-BANNER:END -->
+
 # MiCA Whitepaper
 
 Access Kite's MiCA whitepaper:

--- a/kite-chain/mica-whitepaper.md
+++ b/kite-chain/mica-whitepaper.md
@@ -1,6 +1,6 @@
 <!-- DEPRECATION-BANNER:START -->
 {% hint style="warning" %}
-**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+**⚠️ This version of the docs is deprecated.** The Kite documentation has moved to [docs.gokite.ai](https://docs.gokite.ai), which now replaces this site. Please use the new docs, and file issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
 {% endhint %}
 <!-- DEPRECATION-BANNER:END -->
 

--- a/scripts/add-deprecation-banner.mjs
+++ b/scripts/add-deprecation-banner.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Inserts (or updates) a deprecation banner at the top of every page-level .md
+// file, just below the YAML frontmatter if present. Idempotent: re-running
+// replaces the existing banner block in place. Run from the repo root:
+//
+//   node scripts/add-deprecation-banner.mjs
+//
+// Skips: README.md (which gets a larger banner separately), node_modules/,
+// .git/, .gitbook/, and SUMMARY.md (GitBook sidebar — not user-facing prose).
+
+import { readFile, writeFile, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const BANNER_START = '<!-- DEPRECATION-BANNER:START -->';
+const BANNER_END = '<!-- DEPRECATION-BANNER:END -->';
+
+const BANNER_BLOCK = `${BANNER_START}
+{% hint style="warning" %}
+**⚠️ These docs are moving to a new home.** Preview the new site at [docs-preview.gokite.ai](https://docs-preview.gokite.ai). At cutover, this site will redirect there automatically. File issues against [gokite-ai/kite-docs](https://github.com/gokite-ai/kite-docs).
+{% endhint %}
+${BANNER_END}`;
+
+const SKIP_DIRS = new Set(['node_modules', '.git', '.gitbook']);
+const SKIP_FILES = new Set(['SUMMARY.md']);
+
+async function walk(root, rel = '') {
+  const out = [];
+  for (const entry of await readdir(path.join(root, rel))) {
+    const full = path.join(root, rel, entry);
+    const s = await stat(full);
+    if (s.isDirectory()) {
+      if (entry.startsWith('.') || SKIP_DIRS.has(entry)) continue;
+      out.push(...(await walk(root, path.join(rel, entry))));
+    } else if (entry.endsWith('.md') && !SKIP_FILES.has(entry)) {
+      out.push(path.join(rel, entry));
+    }
+  }
+  return out;
+}
+
+function applyBanner(src) {
+  // 1. If a banner is already present, replace it.
+  if (src.includes(BANNER_START)) {
+    return src.replace(
+      new RegExp(`${BANNER_START}[\\s\\S]*?${BANNER_END}\\n*`),
+      BANNER_BLOCK + '\n\n',
+    );
+  }
+
+  // 2. Otherwise, insert AFTER the frontmatter (if any) or at the very top.
+  const fmMatch = src.match(/^---\n[\s\S]*?\n---\n+/);
+  if (fmMatch) {
+    return fmMatch[0] + BANNER_BLOCK + '\n\n' + src.slice(fmMatch[0].length);
+  }
+  return BANNER_BLOCK + '\n\n' + src;
+}
+
+async function main() {
+  const root = process.argv[2] ?? '.';
+  const files = await walk(root);
+  let updated = 0;
+  for (const rel of files) {
+    const full = path.join(root, rel);
+    const src = await readFile(full, 'utf8');
+    const next = applyBanner(src);
+    if (next !== src) {
+      await writeFile(full, next, 'utf8');
+      updated += 1;
+    }
+  }
+  console.log(`Updated ${updated}/${files.length} files.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added deprecation banners across the site and changelogs directing readers to docs.gokite.ai and the new docs repository for issues; pages will redirect at cutover.
* **Chores**
  * CI workflows updated to allow manual rebuilds.
  * Added an automation tool to insert/update deprecation banners site-wide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->